### PR TITLE
Defer loading widget settings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,7 +12,6 @@ local logger = minilog.logger('off')
 local leader = {timeout = 4}
 
 local hotkeys_popup = require("awful.hotkeys_popup").widget.new()
-hotkeys_popup:_load_widget_settings()
 
 --create a new grabber
 local function make_leadergrabber(map, base_args, finish, ignore_args)
@@ -116,6 +115,7 @@ function leader.sequence(key_binds)
     end
     return {
       f = function (name) return function(args)
+        hotkeys_popup:_load_widget_settings()
         local widget =
           hotkeys_popup:_create_wibox(
             mouse.screen,

--- a/init.lua
+++ b/init.lua
@@ -5,7 +5,7 @@ local math = math
 local mouse = mouse -- luacheck: no global
 local awful = require "awful"
 local gears = require "gears"
-local minilog = require "lua-minilog"
+local minilog = require "awesome-leader.lua-minilog"
 local logger = minilog.logger('off')
 
 


### PR DESCRIPTION
This is to ensure that the user has loaded their theme before we load the widget settings from `beautiful`.

I ran into an issue where requiring awesome-leader before calling `beautiful.init` and then using the `leader.leader` function would throw an error saying that `border_width` is nil. I traced the issue back to the fact that since `hotkeys_popup._load_widget_settings()` was being called when requiring the library, it would load widget settings from the default beautiful theme (which did not have `border_width` set).
Deferring this loading to just before we use it to create a widget makes sure that the user's theme has been loaded. Since `hotkeys_popup._load_widget_settings()` checks to make sure it only runs once, this should not be a problem.